### PR TITLE
Nav bar at bottom of page

### DIFF
--- a/src/components/FooterNav/FooterNav.css
+++ b/src/components/FooterNav/FooterNav.css
@@ -3,6 +3,10 @@
   display: flex;
   flex-direction: row;
   justify-content: space-around;
+  /* position: static; */
+  position: fixed;
+  bottom: 0;
+  width: 100%;
 }
 
 .icon-container {

--- a/src/components/LoginForm/LoginForm.css
+++ b/src/components/LoginForm/LoginForm.css
@@ -1,2 +1,1 @@
-.formPanel {
-}
+


### PR DESCRIPTION
Added CSS styling to keep the nav bar at the bottom of the page, untested since there is currently no good material inside the component to test. Has been moved to testing on the trello board checklist. 